### PR TITLE
call spots + ref spots variables now saved as zarrays to save memory …

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -53,6 +53,7 @@
     checkerboard patten in green and red, with overlapping regions in yellow, and the other for viewing the shifts
     computed for each tile.
  * Call spots: bad_trc now works with the new colour normalisation factor computation fix.
+ * Call spots: some variables now saved as zarr arrays to reduce memory usage and notebook read speed.
  * OMP: OMP is now truly orthogonal. Before, the new gene was weighted using only the residual pixel colour. Now, all 
     genes are re-weighted using the full pixel colour and a new gene is found using the latest residual colour.
  * OMP: After each tile, OMP saves the progress and can continue where it left off if OMP is not completed fully.

--- a/coppafish/pdf/base.py
+++ b/coppafish/pdf/base.py
@@ -329,10 +329,10 @@ class BuildPDF:
         if not os.path.isfile(ref_spots_filepath) and nb.has_page("ref_spots") and nb.has_page("call_spots"):
             with PdfPages(ref_spots_filepath) as pdf:
                 for t in nb.basic_info.use_tiles:
-                    keep = nb.ref_spots.tile == t
+                    keep = nb.ref_spots.tile[:] == t
                     fig = self.create_positions_histograms(
-                        nb.call_spots.dot_product_gene_score[keep],
-                        nb.ref_spots.local_yxz[keep],
+                        nb.call_spots.dot_product_gene_score[:][keep],
+                        nb.ref_spots.local_yxz[:][keep],
                         self.DEFAULT_REF_SCORE_THRESHOLD,
                         title=f"Spot position histograms for {t=}, scores "
                         + r"$\geq$"
@@ -342,8 +342,8 @@ class BuildPDF:
                     pdf.savefig(fig)
                     plt.close(fig)
                 # Create a page for every gene
-                gene_probabilities = nb.call_spots.gene_probabilities
-                scores = nb.ref_spots.colours * nb.call_spots.colour_norm_factor[nb.ref_spots.tile]
+                gene_probabilities = nb.call_spots.gene_probabilities[:]
+                scores = nb.ref_spots.colours[:] * nb.call_spots.colour_norm_factor[nb.ref_spots.tile[:]]
                 n_genes = len(nb.call_spots.gene_names)
                 gene_names = nb.call_spots.gene_names
                 spot_colours_rnorm = scores / np.linalg.norm(scores, axis=2)[:, :, None]
@@ -454,21 +454,21 @@ class BuildPDF:
         file_missing = not os.path.isfile(anchor_heatmap_path) or not os.path.isfile(prob_heatmap_path)
         if nb.has_page("call_spots") and file_missing:
             gene_names = nb.call_spots.gene_names
-            local_yxzs = nb.ref_spots.local_yxz.astype(np.float32)
-            tile_numbers = nb.ref_spots.tile
+            local_yxzs = nb.ref_spots.local_yxz[:].astype(np.float32)
+            tile_numbers = nb.ref_spots.tile[:]
             global_yxzs = local_yxzs + nb.stitch.tile_origin[tile_numbers]
 
             # Anchor heat maps.
-            gene_numbers = nb.call_spots.dot_product_gene_no
-            scores = nb.call_spots.dot_product_gene_score
+            gene_numbers = nb.call_spots.dot_product_gene_no[:]
+            scores = nb.call_spots.dot_product_gene_score[:]
             with PdfPages(anchor_heatmap_path) as pdf:
                 self.create_spatial_heatmaps(
                     pdf, global_yxzs, gene_numbers, scores, gene_names, self.HEATMAP_ANCHOR_SCORE_THRESH
                 )
 
             # Probability heat maps.
-            gene_numbers = np.argmax(nb.call_spots.gene_probabilities, axis=1)
-            scores = nb.call_spots.gene_probabilities.max(1)
+            gene_numbers = np.argmax(nb.call_spots.gene_probabilities[:], axis=1)
+            scores = nb.call_spots.gene_probabilities[:].max(1)
             with PdfPages(prob_heatmap_path) as pdf:
                 self.create_spatial_heatmaps(
                     pdf, global_yxzs, gene_numbers, scores, gene_names, self.HEATMAP_PROB_SCORE_THRESH

--- a/coppafish/pipeline/get_reference_spots.py
+++ b/coppafish/pipeline/get_reference_spots.py
@@ -1,4 +1,7 @@
+import os
+
 import numpy as np
+import zarr
 
 from .. import log
 from ..call_spots import base as call_spots_base
@@ -8,6 +11,7 @@ from ..spot_colours import base as spot_colours_base
 
 def get_reference_spots(
     nbp_basic: NotebookPage,
+    nbp_file: NotebookPage,
     nbp_filter: NotebookPage,
     nbp_find_spots: NotebookPage,
     nbp_register: NotebookPage,
@@ -18,10 +22,10 @@ def get_reference_spots(
     in each of the imaging rounds/channels.
 
     Args:
-        nbp_file: `file_names` notebook page.
         nbp_basic: `basic_info` notebook page.
+        nbp_file: `file_names` notebook page.
+        nbp_filter: `filter` notebook page.
         nbp_find_spots: 'find_spots' notebook page.
-        nbp_extract: `extract` notebook page.
         nbp_register: `register` notebook page.
         nbp_stitch: `stitch` notebook page.
 
@@ -87,6 +91,12 @@ def get_reference_spots(
         spot_colours = np.append(spot_colours, colours[valid], axis=0)
         local_yxz = np.append(local_yxz, nd_local_yxz[in_tile][valid], axis=0)
         tile = np.append(tile, np.ones(valid.sum(), dtype=np.int16) * t)
+
+    # Convert the numpy results to zarrays for saving.
+    kwargs = dict(chunks=False, zarr_version=2)
+    local_yxz = zarr.array(local_yxz, store=os.path.join(nbp_file.output_dir, "local_yxz.zarray"), **kwargs)
+    tile = zarr.array(tile, store=os.path.join(nbp_file.output_dir, "tile.zarray"), **kwargs)
+    spot_colours = zarr.array(spot_colours, store=os.path.join(nbp_file.output_dir, "spot_colours.zarray"), **kwargs)
 
     # save spot info to notebook
     nbp.local_yxz = local_yxz

--- a/coppafish/pipeline/run.py
+++ b/coppafish/pipeline/run.py
@@ -241,6 +241,7 @@ def run_reference_spots(nb: Notebook, nbp_file: NotebookPage) -> None:
     if not nb.has_page("ref_spots"):
         nbp_ref_spots = get_reference_spots.get_reference_spots(
             nbp_basic=nb.basic_info,
+            nbp_file=nbp_file,
             nbp_filter=nb.filter,
             nbp_find_spots=nb.find_spots,
             nbp_register=nb.register,

--- a/coppafish/plot/call_spots/scores.py
+++ b/coppafish/plot/call_spots/scores.py
@@ -42,9 +42,9 @@ class HistogramScore:
         self.genes_use = np.arange(self.n_genes)
 
         # Get spot colors
-        spot_colours_raw = nb.ref_spots.colours
+        spot_colours_raw = nb.ref_spots.colours[:]
         colour_norm_factor = nb.call_spots.colour_norm_factor
-        spot_tile = nb.ref_spots.tile
+        spot_tile = nb.ref_spots.tile[:]
         spot_colours = spot_colours_raw * colour_norm_factor[spot_tile]
         spot_colours_bg = np.repeat(np.percentile(spot_colours, 25, axis=1)[:, None, :], self.n_rounds, axis=1)
         spot_colours_bg_removed = spot_colours - spot_colours_bg

--- a/coppafish/plot/call_spots/spot_colours.py
+++ b/coppafish/plot/call_spots/spot_colours.py
@@ -641,17 +641,17 @@ class GeneSpotsViewer:
             )
             spot_index = np.concatenate([np.arange(nb.omp.results[f"tile_{t}"].scores.shape[0]) for t in use_tiles])
         elif self.mode == "anchor":
-            spots = nb.ref_spots.colours
-            gene_no = nb.call_spots.dot_product_gene_no
-            score = nb.call_spots.dot_product_gene_score
-            tile = nb.ref_spots.tile
-            spot_index = np.arange(len(nb.ref_spots.colours))
+            spots = nb.ref_spots.colours[:]
+            gene_no = nb.call_spots.dot_product_gene_no[:]
+            score = nb.call_spots.dot_product_gene_score[:]
+            tile = nb.ref_spots.tile[:]
+            spot_index = np.arange(nb.ref_spots.colours.shape[0])
         else:
-            spots = nb.ref_spots.colours
-            gene_no = np.argmax(nb.call_spots.gene_probabilities, axis=1)
-            score = np.max(nb.call_spots.gene_probabilities, axis=1)
-            tile = nb.ref_spots.tile
-            spot_index = np.arange(len(nb.ref_spots.colours))
+            spots = nb.ref_spots.colours[:]
+            gene_no = np.argmax(nb.call_spots.gene_probabilities[:], axis=1)
+            score = np.max(nb.call_spots.gene_probabilities[:], axis=1)
+            tile = nb.ref_spots.tile[:]
+            spot_index = np.arange(nb.ref_spots.colours.shape[0])
 
         # get spots for gene gene_index with score > score_threshold for current mode and valid spots
         invalid = np.any(np.isnan(spots), axis=(1, 2))
@@ -814,13 +814,13 @@ class ViewScalingAndBGRemoval:
     def __init__(self, nb):
         plt.style.use("dark_background")
         self.nb = nb
-        spot_tile = nb.ref_spots.tile
+        spot_tile = nb.ref_spots.tile[:]
         n_spots = spot_tile.shape[0]
         n_rounds, n_channels_use = len(nb.basic_info.use_rounds), len(nb.basic_info.use_channels)
         norm_factor = nb.call_spots.colour_norm_factor
 
         # get spot colours raw, no_bg and normed_no_bg
-        spot_colour_raw = nb.ref_spots.colours.copy()
+        spot_colour_raw = nb.ref_spots.colours[:].copy()
         spot_colour_normed = spot_colour_raw * norm_factor[spot_tile]
         bg = np.repeat(np.percentile(spot_colour_normed, 25, axis=1)[:, None, :], n_rounds, axis=1)
         spot_colour_normed_no_bg = spot_colour_normed - bg

--- a/coppafish/plot/results_viewer/base.py
+++ b/coppafish/plot/results_viewer/base.py
@@ -559,17 +559,17 @@ class Viewer:
         colour_norm_factor = nb.call_spots.colour_norm_factor
 
         # initialise relevant information for anchor and prob methods
-        tile = [nb.ref_spots.tile, nb.ref_spots.tile]
-        local_loc = [nb.ref_spots.local_yxz, nb.ref_spots.local_yxz]
+        tile = [nb.ref_spots.tile[:], nb.ref_spots.tile[:]]
+        local_loc = [nb.ref_spots.local_yxz[:], nb.ref_spots.local_yxz[:]]
         global_loc = [(local_loc[i] + tile_origin[tile[i]])[:, [2, 0, 1]] for i in range(2)]  # convert to zyx
         # apply downsample factor
         global_loc = [loc // downsample_factor for loc in global_loc]
-        colours = [nb.__getattribute__(self.method["pages"][i]).colours.copy() for i in range(2)]
+        colours = [nb.__getattribute__(self.method["pages"][i]).colours[:].copy() for i in range(2)]
         colours = [colours[i] * colour_norm_factor[tile[i]] for i in range(2)]
-        score = [nb.call_spots.dot_product_gene_score, np.max(nb.call_spots.gene_probabilities, axis=1)]
-        gene_no = [nb.call_spots.dot_product_gene_no, np.argmax(nb.call_spots.gene_probabilities, axis=1)]
-        intensity = [nb.call_spots.intensity, nb.call_spots.intensity]
-        indices = [np.arange(len(nb.ref_spots.tile)), np.arange(len(nb.ref_spots.tile))]
+        score = [nb.call_spots.dot_product_gene_score[:], np.max(nb.call_spots.gene_probabilities[:], axis=1)]
+        gene_no = [nb.call_spots.dot_product_gene_no[:], np.argmax(nb.call_spots.gene_probabilities[:], axis=1)]
+        intensity = [nb.call_spots.intensity[:], nb.call_spots.intensity[:]]
+        indices = [np.arange(nb.ref_spots.tile.size), np.arange(nb.ref_spots.tile.size)]
 
         # add omp results to the lists
         if nb.has_page("omp"):

--- a/coppafish/plot/viewer2d/base.py
+++ b/coppafish/plot/viewer2d/base.py
@@ -153,7 +153,7 @@ class Viewer2D:
             ]
 
         # Keep gene positions and scores inside the Viewer2D instance.
-        self.anchor_global_yxz = nb.ref_spots.local_yxz + nb.stitch.tile_origin[nb.ref_spots.tile]
+        self.anchor_global_yxz = nb.ref_spots.local_yxz[:] + nb.stitch.tile_origin[nb.ref_spots.tile[:]]
         self.anchor_gene_no = nb.call_spots.dot_product_gene_no
         self.anchor_score = nb.call_spots.dot_product_gene_score
         self.probs_global_yxz = self.anchor_global_yxz

--- a/coppafish/robominnie/robominnie.py
+++ b/coppafish/robominnie/robominnie.py
@@ -665,15 +665,15 @@ class Robominnie:
         assert nb.has_page("ref_spots"), f"Reference spots not found in notebook at {config_filepath}"
         assert nb.has_page("call_spots")
 
-        self.prob_spots_positions = nb.ref_spots.local_yxz.astype(np.float32)
-        self.prob_spots_scores = nb.call_spots.gene_probabilities.max(1)
-        self.prob_spots_gene_indices = np.argmax(nb.call_spots.gene_probabilities, 1)
-        self.prob_spots_tile = nb.ref_spots.tile
+        self.prob_spots_positions = nb.ref_spots.local_yxz[:].astype(np.float32)
+        self.prob_spots_scores = nb.call_spots.gene_probabilities[:].max(1)
+        self.prob_spots_gene_indices = np.argmax(nb.call_spots.gene_probabilities[:], 1)
+        self.prob_spots_tile = nb.ref_spots.tile[:]
 
-        self.ref_spots_local_positions_yxz = nb.ref_spots.local_yxz.astype(np.float32)
-        self.ref_spots_scores = nb.call_spots.dot_product_gene_score
-        self.ref_spots_gene_indices = nb.call_spots.dot_product_gene_no
-        self.ref_spots_tile = nb.ref_spots.tile
+        self.ref_spots_local_positions_yxz = nb.ref_spots.local_yxz[:].astype(np.float32)
+        self.ref_spots_scores = nb.call_spots.dot_product_gene_score[:]
+        self.ref_spots_gene_indices = nb.call_spots.dot_product_gene_no[:]
+        self.ref_spots_tile = nb.ref_spots.tile[:]
 
         end_time = time.time()
         print(

--- a/coppafish/setup/test/test_setup_notebook.py
+++ b/coppafish/setup/test/test_setup_notebook.py
@@ -149,7 +149,7 @@ def test_notebook_creation() -> None:
 
     try:
         nb += nb_page
-        assert False, f"Shoul not be able to add an unfinished page to the notebook"
+        assert False, f"Should not be able to add an unfinished page to the notebook"
     except ValueError:
         pass
 
@@ -207,3 +207,7 @@ def test_notebook_creation() -> None:
     # Clean any temporary files/directories.
     temp_zarr.cleanup()
     temp_zgroup.cleanup()
+
+
+if __name__ == "__main__":
+    test_notebook_creation()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 markers = [
     "manual: tests only run manually",
     "integration: integration tests",
+    "notebook: tests that can only run with a completed robominnie notebook (after an integration test)",
 ]
 
 [tool.black]


### PR DESCRIPTION
…and nb load time. Completes issues #94 and #95.

Note: This will remove backwards compatibility with older v1 test versions from call spots onwards.

### Checklist
- [x] I have updated the `changelog.txt`, if applicable.
- [ ] I have bumped the software version in `_version.py`, if applicable.
- [x] I have checked that the unit tests passed.
- [x] I have checked that Minnie and/or RoboMinnie passed.
- [x] I have resolved merge conflicts.
