### PR TITLE
Fix tile numbers on upstairs microscope

### DIFF
--- a/coppafisher/extract/nd2.py
+++ b/coppafisher/extract/nd2.py
@@ -76,6 +76,9 @@ def get_metadata(file_path: str, config: dict) -> dict:
         xy_pos = np.array(
             [images.experiment[0].parameters.points[i].stagePositionUm[:2] for i in range(images.sizes["P"])]
         )
+        reverse_x = -1 if config['basic_info']['reverse_tile_positions_x'] else 1
+        reverse_y = -1 if config['basic_info']['reverse_tile_positions_y'] else 1
+        xy_pos = xy_pos * [reverse_x, reverse_y]
         xy_pos = (xy_pos - np.min(xy_pos, 0)) / metadata["pixel_size_xy"]
         metadata["xy_pos"] = xy_pos
         metadata["tilepos_yx_nd2"], metadata["tilepos_yx"] = tile_details.get_tilepos(

--- a/coppafisher/pipeline/basic_info.py
+++ b/coppafisher/pipeline/basic_info.py
@@ -94,14 +94,6 @@ def set_basic_info(config: Config) -> NotebookPage:
             value = np.array(value)
         nbp.__setattr__(key, value)
 
-    # Reverse the tile positions from raw tiles, if true.
-    reversed_tilepos_yx_nd2 = nbp.tilepos_yx_nd2
-    del nbp.tilepos_yx_nd2
-    reversed_tilepos_yx_nd2 = tile_details.reverse_raw_tile_positions(
-        reversed_tilepos_yx_nd2, config_basic["reverse_tile_positions_x"], config_basic["reverse_tile_positions_y"]
-    )
-    nbp.tilepos_yx_nd2 = reversed_tilepos_yx_nd2
-
     # Stage 4: If anything from the first 12 entries has been left blank, deal with that here.
     # Unfortunately, this is just many if statements as all blank entries need to be handled differently.
     # Notebook doesn't allow us to reset a value once it has been set so must delete and reset.

--- a/coppafisher/setup/tile_details.py
+++ b/coppafisher/setup/tile_details.py
@@ -4,49 +4,6 @@ from typing import List, Optional, Tuple
 import numpy as np
 
 
-def reverse_raw_tile_positions(
-    raw_tile_positions: np.ndarray[np.integer], reverse_x: bool, reverse_y: bool
-) -> np.ndarray[np.integer]:
-    """
-    Reverse x and/or y (or neither) raw tile orderings based on the given bool flags.
-
-    This is used by users when the raw tiles appear the wrong way around. The function simply rearranges the tile
-    positions in the array, this places the tiles at different positions since they change order relative to tilepos_yx
-    since they are unchanged.
-
-    Args:
-        raw_tile_positions (`(n_tiles x 2) ndarray[int]`): the positions of all tiles from the raw, input data.
-            raw_tile_positions[i] is the i'th tiles position y and x position.
-        reverse_x (bool): reverse the tile positions along the x axis.
-        reverse_y (bool): reverse the tile positions along the y axis.
-
-    Returns:
-        (`(n_tiles x 2) ndarray[int]`): new_raw_tile_positions. The reversed raw tile positions copy.
-    """
-    assert type(raw_tile_positions) is np.ndarray
-    assert raw_tile_positions.ndim == 2
-    assert raw_tile_positions.shape[1] == 2
-    assert type(reverse_x) is bool
-    assert type(reverse_y) is bool
-
-    output = raw_tile_positions.copy()
-    tile_count_yx = output.max(0) - output.min(0) + 1
-
-    if reverse_x:
-        for y in range(tile_count_yx[0]):
-            indices = list(range(output.shape[0]))
-            ind_min, ind_max = y * tile_count_yx[1], y * tile_count_yx[1] + tile_count_yx[1]
-            indices[ind_min:ind_max] = indices[ind_min:ind_max][::-1]
-            output = output[indices]
-    if reverse_y:
-        # Y positions are sorted from maximum first to minimum last (reversed ordering). Stable is true to preserve the
-        # ordering of the X positions.
-        indices = np.argsort(output[:, 0].max() - output[:, 0], stable=True).tolist()
-        output = output[indices]
-
-    return output
-
-
 def get_tilepos(xy_pos: np.ndarray, tile_sz: int, expected_overlap: float) -> Tuple[np.ndarray, np.ndarray]:
     """
     Using `xy_pos` from nd2 metadata, this obtains the yx position of each tile. We label the tiles differently in the


### PR DESCRIPTION
Currently, the tile numbers are strange for the upstairs microscope because it uses a stage that has the coordinate system reversed compared to the downstairs one.  The previous implementation made it difficult to select the appropriate tiles: the get_tilepos() function did not return the actual tile positions, so it was difficult to determine which nd2 tile mapped to which coppafisher tile without running the entire pipeline. (This is important when running a subset of tiles.)  I believe there was also some strange behaviour, as I was getting tiles from seemingly random nd2 positions stitched together as if they were neighbours, but I did not try to debug the existing function.

The present implementation is simpler and simply reverses the stage coordinates.   This also is conceptually simpler and pushes the reversal upstream, making it easier to maintain and keep the notebook file in sync.  You still cannot call get_tilepos directly on the nd2 coordinates, but there is a simple transformation (negation) that can be run first. 

I tested it on one subset of one dataset (fir11) and it appears to be working properly.