### PR TITLE
160 napari update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -67,8 +67,8 @@ matplotlib-inline==0.1.7
 mdurl==0.1.2
 mplcursors==0.5.3
 mpmath==1.3.0
-napari==0.5.4
-napari-console==0.1.0
+napari==0.5.6
+napari-console==0.1.3
 napari-plugin-engine==0.2.0
 napari-svg==0.2.0
 nd2==0.10.1
@@ -108,6 +108,7 @@ PyQt5-Qt5==5.15.2
 PyQt5_sip==12.15.0
 python-dateutil==2.9.0.post0
 pytz==2024.2
+pywin32==308; sys.platform == 'win32'
 PyYAML==6.0.2
 pyzmq==26.2.0
 qtconsole==5.6.0


### PR DESCRIPTION
- **[pdf] PDF gene heat maps are now logarithmic colour scaled, closes #194**
- **[viewer] tailed_arrow in gene marker file now supported**
- **[viewer] gene marker symbol docs**
- **[changelog] update**
- **[version] bump**
- **[config] compatibility version bump**
- **[viewer] optimised max intensity projection bg image by making it 2d**
- **[viewer] [docs] multiple background support, closes #196**
- **[changelog] update**
- **[viewer] background_images can no longer be None**
- **[docs] viewer update**
- **[viewer] toggle layer visibility with multiple backgrounds fix**
- **[viewer] multiple background images tested**
- **[extract] [changelog] image chunks no longer too small fix, closes #199**
- **[CI] timeout bump**
- **[viewer] high-precision anchor/dapi image support**
- **Annotations for gene legend in viewer**
- **[viewer] high-precision background image generation fixes + better contrast limiting**
- **[changelog] update**
- **[version] bump**
- **[config] 1.0.3 compatibility info added**
- **[viewer] missing config parameter in unit test fix**
- **[viewer] better docstring**
- **[call spots] removed unused function `fit_background`**
- **Update gene colour labels**
- **[viewer] black formatting changes**
- **[viewer] no cell_type gene marker file test**
- **[changelog] update**
- **[config] Python 3.10 support dropped, closes #173**
- **[viewer] global background fixes + unit test added**
- **[if] if alignment extraction added, starts #206**
- **[config] unraised unit test exception on Unix fix**
- **[config] if __name__ code removed**
- **[viewer] better unit test**
- **[if] extract fixes**
- **[pciseq] stricter `export_to_pciseq` unit tests**
- **[viewer] use_tiles is a subset of n_tiles fixes for detailed background images**
- **[viewer] background image now the detailed dapi by default**
- **[changelog] update**
- **[viewer] [pciseq] 'dapi' bg image no longer supported in Viewer, new export_pciseq_dapi_image for pciseq**
- **[viewer] fused background image can now have any output dtype**
- **[if] [docs] custom image stitching added**
- **Fix tile numbers on upstairs microscope**
- **[docs] custom image stitch and registration added, closes #206**
- **[changelog] update**
- **[docs] update**
- **[config] delete redundant unit test**
- **[precommit] fixes**
- **[changelog] 1.0.3 date bump**
- **[docs] updates**
- **[pdf] log10 of <= 0 values fix**
- **[pciseq] [docs] export unfiltered DAPI image for pciseq added, closes #216**
- **[changelog] update**
- **[docs] fixes**
- **[extract] [docs] support raw anchor round with different raw channel indices, closes #212**
- **[setup]  sometimes wrongly classified fix**
- **[extract] raw anchor_channel indexing fix**
- **[export] use the notebook stitch result when stitching custom images, closes #221**
- **[changelog] update**
- **[export] custom images are stitched separately but aligned/shaped relative to the anchor-dapi**
- **[export] np.nan values + negative crop amount fix**
- **[utils] compute intensity utils function added, closes #186**
- **[export] tile stitch rounding error in DAPI background image versus spot positions fix, closes #227**
- **[changelog] update**
- **[export] floor only the minimum tile origin values in background image creation**
- **[setup] python 3.12 support added, closes #174**
- **[CI] python 3.12 tests added**
- **[export] custom image alignment now aligned with exported spot positions fix**
- **[changelog] date bump**
- **[export] tile indices correctly ordered**
- **[setup] napari 0.5.4 -> 0.5.6**
