### PR TITLE
[call spots] intensity threshold spot selection, closes #337 + initial probabilities in Viewer + OMP default tweak

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
  * Call spots: 25th percentile "background subtraction" colour pre-processing step is now optional and is off by
     default.
  * Call spots: Intensity threshold on good spot selection added.
+ * OMP: Default dot_product_threshold 0.50 -> 0.72.
 
 
 2025/05/12 Version 1.2 Patch (v1.2.6):

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
  * Find spots: Improved error message.
  * Call spots: 25th percentile "background subtraction" colour pre-processing step is now optional and is off by
     default.
+ * Call spots: Intensity threshold on good spot selection added.
 
 
 2025/05/12 Version 1.2 Patch (v1.2.6):

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 2025/MM/DD Version 1.3 (v1.3.0):
  * General: New ND2 file tile indexing plot added.
  * General: pyproject.toml file added to replace setup.py.
+ * Viewer: "prob" gene calling method now shows the initial Von-Mises spot probabilities.
  * Export: Load transform from text file instructions fixed.
  * Find spots: Improved error message.
  * Call spots: 25th percentile "background subtraction" colour pre-processing step is now optional and is off by

--- a/coppafisher/plot/call_spots/parameter_estimation.py
+++ b/coppafisher/plot/call_spots/parameter_estimation.py
@@ -64,7 +64,7 @@ class ViewFreeAndConstrainedBledCodes:
         for g in range(n_genes):
             code_image[g, :, :n_rounds] = free_bled_codes[g]
             code_image[g, :, -n_rounds:] = constrained_bled_codes[g]
-            n_spots[g] = np.sum(np.argmax(nb.call_spots.gene_probabilities, axis=1) == g)
+            n_spots[g] = np.sum(np.argmax(nb.call_spots.gene_probabilities_initial, axis=1) == g)
 
         # add the attributes
         self.code_image = code_image
@@ -202,7 +202,7 @@ class ViewTargetRegression:
         # get the number of spots per gene
         n_spots = np.zeros(n_genes, dtype=int)
         for g in range(n_genes):
-            n_spots[g] = np.sum(np.argmax(nb.call_spots.gene_probabilities, axis=1) == g)
+            n_spots[g] = np.sum(np.argmax(nb.call_spots.gene_probabilities_initial, axis=1) == g)
 
         # add the attributes
         self.r, self.c = r, c
@@ -372,7 +372,7 @@ def ViewTileScaleRegression(
     d_max = config["d_max"]
     target_bled_codes = nb.call_spots.bled_codes
     free_bled_codes = nb.call_spots.free_bled_codes
-    gene_no = np.argmax(nb.call_spots.gene_probabilities[:], axis=1)
+    gene_no = np.argmax(nb.call_spots.gene_probabilities_initial[:], axis=1)
     n_spots = np.array([np.sum(gene_no == i) for i in range(nb.call_spots.gene_names.size)])
     use_channels = nb.basic_info.use_channels
     n_tiles, n_rounds, n_channels_use = tile_scale.shape

--- a/coppafisher/plot/call_spots/scores.py
+++ b/coppafisher/plot/call_spots/scores.py
@@ -284,8 +284,8 @@ class ViewAllGeneHistograms:
                 gene_values = self.nb.call_spots.dot_product_gene_score
                 gene_no = self.nb.call_spots.dot_product_gene_no
             else:
-                gene_values = np.max(self.nb.call_spots.gene_probabilities, axis=1)
-                gene_no = np.argmax(self.nb.call_spots.gene_probabilities, axis=1)
+                gene_values = np.max(self.nb.call_spots.gene_probabilities_initial, axis=1)
+                gene_no = np.argmax(self.nb.call_spots.gene_probabilities_initial, axis=1)
             gene_hists[m] = [
                 np.histogram(gene_values[gene_no == g], bins=np.linspace(0, 1, 10))[0]
                 for g in range(len(self.nb.call_spots.gene_names))

--- a/coppafisher/plot/call_spots/spot_colours.py
+++ b/coppafisher/plot/call_spots/spot_colours.py
@@ -321,8 +321,8 @@ class ViewGeneEfficiencies(Subplot):
             gene_no = nbp_call_spots.dot_product_gene_no
             score = nbp_call_spots.dot_product_gene_score
         else:
-            gene_no = np.argmax(nbp_call_spots.gene_probabilities[:], axis=1)
-            score = np.max(nbp_call_spots.gene_probabilities[:], axis=1)
+            gene_no = np.argmax(nbp_call_spots.gene_probabilities_initial[:], axis=1)
+            score = np.max(nbp_call_spots.gene_probabilities_initial[:], axis=1)
 
         # Count the number of spots for each gene
         n_spots = np.zeros(nbp_call_spots.gene_names.shape[0], dtype=int)
@@ -466,8 +466,8 @@ class GeneSpotsViewer:
             spot_index = np.arange(nbp_ref_spots.colours.shape[0])
         else:
             spots = nbp_ref_spots.colours[:]
-            gene_no = np.argmax(nbp_call_spots.gene_probabilities[:], axis=1)
-            score = np.max(nbp_call_spots.gene_probabilities[:], axis=1)
+            gene_no = np.argmax(nbp_call_spots.gene_probabilities_initial[:], axis=1)
+            score = np.max(nbp_call_spots.gene_probabilities_initial[:], axis=1)
             tile = nbp_ref_spots.tile[:]
             spot_index = np.arange(nbp_ref_spots.colours.shape[0])
 

--- a/coppafisher/plot/results_viewer/base.py
+++ b/coppafisher/plot/results_viewer/base.py
@@ -44,12 +44,12 @@ class Viewer:
     _method_to_string: dict[str, str] = {"prob": "Probability", "anchor": "Anchor", "omp": "OMP"}
     _gene_legend_order_by_options: tuple[str, ...] = ("row", "colour", "cell_type")
     _starting_score_thresholds: dict[str, tuple[float, float | None]] = {
-        "prob": (0.5, None),
+        "prob": (0.9, None),
         "anchor": (0.5, None),
         "omp": (0.4, None),
     }
     _starting_intensity_thresholds: dict[str, tuple[float, float | None]] = {
-        "prob": (0.15, None),
+        "prob": (0.20, None),
         "anchor": (0.15, None),
         "omp": (0.15, None),
     }

--- a/coppafisher/plot/results_viewer/test/test_plot_results_viewer_base.py
+++ b/coppafisher/plot/results_viewer/test/test_plot_results_viewer_base.py
@@ -77,7 +77,7 @@ def test_Viewer() -> None:
     # Normalise bled codes as this is checked by other functions.
     bled_codes /= np.linalg.norm(bled_codes, axis=(1, 2), keepdims=True)
     nbp_call_spots.bled_codes = bled_codes
-    nbp_call_spots.gene_probabilities = zarr.array(rng.rand(n_ref_spots, n_genes).astype(np.float32))
+    nbp_call_spots.gene_probabilities_initial = zarr.array(rng.rand(n_ref_spots, n_genes).astype(np.float32))
     nbp_call_spots.intensity = zarr.array(rng.rand(n_ref_spots) + 0.5).astype(np.float32)
     nbp_call_spots.dot_product_gene_no = zarr.array(rng.randint(n_genes, size=n_ref_spots, dtype=np.int16))
     nbp_call_spots.dot_product_gene_score = zarr.array(rng.rand(n_ref_spots)).astype(np.float16)

--- a/coppafisher/results/base.py
+++ b/coppafisher/results/base.py
@@ -61,14 +61,14 @@ class MethodData:
         self.method = method
 
         if method == "prob":
-            self.score = nbp_call_spots.gene_probabilities[:].max(1)
+            self.score = nbp_call_spots.gene_probabilities_initial[:].max(1)
         if method == "anchor":
             self.score = nbp_call_spots.dot_product_gene_score[:]
         if method in ("prob", "anchor"):
             self.tile = nbp_ref_spots.tile[:]
             self.local_yxz = nbp_ref_spots.local_yxz[:].astype(np.int16)
             self.yxz = self.local_yxz.astype(np.float32) + nbp_stitch.tile_origin[self.tile]
-            self.gene_no = np.argmax(nbp_call_spots.gene_probabilities[:], 1).astype(np.int16)
+            self.gene_no = np.argmax(nbp_call_spots.gene_probabilities_initial[:], 1).astype(np.int16)
             self.colours = nbp_ref_spots.colours[:].astype(np.float32)
             self.intensity = nbp_call_spots.intensity[:]
         if method == "omp":

--- a/coppafisher/results/test/test_results_pciseq.py
+++ b/coppafisher/results/test/test_results_pciseq.py
@@ -36,7 +36,7 @@ def test_export_to_pciseq() -> None:
         assert csv_file_path.endswith(f"pciseq_{method}.csv")
 
         if method == "prob":
-            n_expected_genes = (nb.call_spots.gene_probabilities[:].max(1) >= 0.5).sum()
+            n_expected_genes = (nb.call_spots.gene_probabilities_initial[:].max(1) >= 0.5).sum()
         elif method == "anchor":
             n_expected_genes = (nb.call_spots.dot_product_gene_score[:] >= 0.5).sum()
         elif method == "omp":

--- a/coppafisher/setup/config.py
+++ b/coppafisher/setup/config.py
@@ -221,6 +221,7 @@ class Config:
         "call_spots": {
             "background_subtract": ("bool", ""),
             "gene_prob_threshold": ("number", "not-negative"),
+            "gene_intensity_threshold": ("number", "not-negative"),
             "target_values": ("maybe_tuple_number", "tuple-not-empty"),
             "d_max": ("maybe_tuple_int", "tuple-not-empty"),
             "kappa": ("maybe_number", "not-negative"),

--- a/coppafisher/setup/default.ini
+++ b/coppafisher/setup/default.ini
@@ -383,9 +383,9 @@ alpha = 120
 ; Check the OMP method in the docs for details.
 beta = 1
 
-; Pixels only have a new gene assignment when that gene has an absolute `dot_product_score` greater than
+; Pixels only get a new gene assignment when that gene has an absolute `dot_product_score` greater than
 ; dot_product_threshold. Therefore, this is a stopping criterion for OMP.
-dot_product_threshold = 0.50
+dot_product_threshold = 0.72
 
 ; The number of pixels that pixel scores are computed on at once. If blank, the number of pixels is calculated based on
 ; the available PC memory.

--- a/coppafisher/setup/default.ini
+++ b/coppafisher/setup/default.ini
@@ -321,17 +321,21 @@ icp_max_iter = 50
 ; normalisation factors.
 background_subtract = false
 
-; this is the threshold for spots to be used for computing bled codes (tile independent and tile dependent), the
+; This is the threshold for spots to be used for computing bled codes (tile independent and tile dependent), the
 ; bleed matrix and thus subsequently the scale factors.
 gene_prob_threshold = 0.9
 
-; this is a list of length n_channels_use and specifies the target brightness for each channel in its brightest dye.
+; The intensity threshold applied to remove dim, noisy spots from the spot selection used during call spots. Both the
+; probability threshold and the intensity threshold must be met for a spot to be used.
+gene_intensity_threshold = 0.2
+
+; This is a list of length n_channels_use and specifies the target brightness for each channel in its brightest dye.
 ; for 7 channels we typically use [1, 1, 0.9, 0.7, 0.8, 1, 1] as the target values.
 ; for 9 channels we typically use [1, 0.8, 0.2, 0.9, 0.6, 0.8, 0.3, 0.7, 1] as the target values.
 ; If left blank, pipeline will check n_channels_use and set to the relevant option above.
 target_values =
 
-; this is a list of length n_channels_use and specifies the dye we will make brightest for each channel
+; This is a list of length n_channels_use and specifies the dye we will make brightest for each channel
 ; for 7 channels we typically use [0, 1, 3, 2, 4, 5, 6] as the target values.
 ; for 9 channels we typically use 0, 1, 1, 3, 2, 4, 5, 5, 6 as the target values.
 ; If left blank, pipeline will check n_channels_use and set to the relevant option above.
@@ -343,11 +347,11 @@ d_max =
 ; If left blank, pipeline will check how may genes are used and set it to log(1 + n_genes // 75) + 2
 kappa =
 
-; this is the number of spots necessary to significantly alter the mean vector of spot colours parallel to the
+; This is the number of spots necessary to significantly alter the mean vector of spot colours parallel to the
 ; expected colour
 concentration_parameter_parallel = 10
 
-; this is the number of spots necessary to significantly alter the mean vector of spot colours perpendicular to the
+; This is the number of spots necessary to significantly alter the mean vector of spot colours perpendicular to the
 ; expected colour
 concentration_parameter_perpendicular = 50
 

--- a/coppafisher/spot_colours/base.py
+++ b/coppafisher/spot_colours/base.py
@@ -262,7 +262,7 @@ def get_spot_colours_new(
 
     # TODO: Vectorise applying flow and affine transforms.
     yxz_t = torch.full((len(use_rounds), len(use_channels), yxz.shape[0], 3), torch.nan, dtype=torch.float32)
-    for r in use_rounds:
+    for r_index, r in enumerate(use_rounds):
         # image_tr = np.zeros((len(use_channels), 1) + tile_shape, np.float32)
         yxz_tr = torch.zeros((len(use_channels), yxz.shape[0], 3), dtype=torch.float32)
         # First, apply round r optical flow to the given coordinates.
@@ -274,7 +274,7 @@ def get_spot_colours_new(
             del yxz_trc
         del yxz_r
 
-        yxz_t[r] = yxz_tr
+        yxz_t[r_index] = yxz_tr
         del yxz_tr
 
     # Gather the smallest sized cuboid of filter image data to bilinear-interpolate all yxz_t coordinates.
@@ -286,13 +286,13 @@ def get_spot_colours_new(
     subset_tile_shape: tuple[int, int, int] = tuple([yxz_t_max[i] - yxz_t_min[i] for i in range(3)])
 
     image_t = torch.zeros((len(use_rounds), len(use_channels), 1) + subset_tile_shape, dtype=torch.float32)
-    for r in use_rounds:
+    for r_index, r in enumerate(use_rounds):
         for c_index, c in enumerate(use_channels):
             image_trc = image[
                 tile, r, c, yxz_t_min[0] : yxz_t_max[0], yxz_t_min[1] : yxz_t_max[1], yxz_t_min[2] : yxz_t_max[2]
             ]
             image_trc = torch.from_numpy(image_trc).float()
-            image_t[r, c_index, 0] = image_trc
+            image_t[r_index, c_index, 0] = image_trc
 
     image_t = image_t.reshape((len(use_rounds) * len(use_channels), 1) + subset_tile_shape)
     yxz_t = yxz_t.reshape((len(use_rounds) * len(use_channels), 1, 1, yxz.shape[0], 3))

--- a/coppafisher/utils/intensity.py
+++ b/coppafisher/utils/intensity.py
@@ -23,4 +23,5 @@ def compute_intensity(colours: np.ndarray[np.floating] | torch.Tensor) -> torch.
         intensities = torch.from_numpy(colours)
     elif type(colours) is torch.Tensor:
         intensities = colours.clone()
+
     return intensities.abs().max(2).values.min(1).values

--- a/docs/call_spots.md
+++ b/docs/call_spots.md
@@ -51,9 +51,17 @@ for all spots $s$ in tile $t$. This is a good estimate of the scaling factor nee
     F_{src} \mapsto F_{src} - \text{Percentile}_r(F_{src}, 25)
     $$
 
-    For 7 rounds, this is the brightness of the second dimmest round of the scaled spot colours in channel cc. This is a good estimate of the constant signal in channel cc across all rounds, which we want to remove.
+    For 7 rounds, this is the brightness of the second dimmest round of the scaled spot colours in channel c. This is a good estimate of the constant signal in channel c across all rounds, which we want to remove.
 
 <!-- TODO: Add an image of a spot before anything, after scaling -->
+
+We define the intensity of spot $s$ as
+
+$$
+I(s) = \min_r\Big(\max_c(|F_{src}|)\Big)
+$$
+
+which will be useful later for refined spot selection by ensuring there is brightness in every sequencing round.
 
 ### 1: Initial Gene Assignment
 The purpose of this step is to provide some preliminary gene assignments that will allow us to estimate the bleed matrix and the bled codes. We will work extensively with the bleed matrix in these calculations, but bear in mind that this is the raw bleed matrix $\mathbf{B_{\textrm{raw}}}$.
@@ -171,10 +179,12 @@ where $\kappa$ is a concentration parameter which controls how much the probabil
 ### 2: Bleed Matrix Calculation
 The purpose of this step is to compute an updated estimate of the bleed matrix.
 
-Set some probability threshold $\gamma$ (in the config file $\gamma$ is called `gene_prob_thresold` and has default value 0.9). We define the following sets:
+Set some probability threshold $\gamma$ (in the config file $\gamma$ is called `gene_prob_thresold` and has default value 0.9).
+Set an intensity threshold $\delta$ (in the config file $\delta$ is called `gene_intensity_threshold` and has default value 0.2).
+We define the following sets:
 
 $$
-\mathcal{S} = \{ s : p(s) \geq \gamma \},
+\mathcal{S} = \{ s : p(s) > \gamma \space \cap \space I(s) > \delta \},
 $$
 
 $$
@@ -187,11 +197,11 @@ $$
 
 In words, these can be described as follows:
 
-- $\mathcal{S}$ is the set of spots with $s$ with probability $p(s) > \gamma$, ie: the high probability spots,
+- $\mathcal{S}$ is the set of spots with $s$ with high probability/intense spots,
 
 - $G_{rd}$ is the set of genes with dye $d$ in round $r$,
 
-- $J_{rd}$ is the set of colours of high probability spots assigned to genes with dye $d$ in round $r$.
+- $J_{rd}$ is the set of colours of high probability/intense spots assigned to genes with dye $d$ in round $r$.
 
 By taking the union of $J_{rd}$ across rounds, we end up with a set of reliable colour vector estimates for dye $d$:
 
@@ -457,11 +467,11 @@ An intensity for each spot is saved to the notebook and used in the [Viewer](dia
 from the final, scaled colours.
 
 $$
-\text{intensity}_s = \min_r(\max_c(\mathbf{F}_{src}))
+\text{intensity}_s = \min_r(\max_c(|\mathbf{F}_{src}|))
 $$
 
 This intensity should have a threshold when looking at gene results as it removes poor gene reads caused by colour that
-is bright in only some of the rounds. From data, a value of 0.1 is reasonable. This is the default threshold for the
+is bright in only some of the rounds. From data, a value of 0.15 is reasonable. This is the default threshold for the
 Viewer.
 
 ??? note "What could cause brightness in some rounds but not others?"

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -64,10 +64,10 @@ be a .npy file, a compressed .npz file with image at key `"arr_0"`, or a .tif fi
 
     With multiple background images, you will not see a background contrast slider anymore. This is intentional. To
     change the settings of each background image, click on Window -> Layer List and Window -> Layer Controls. From these
-    windows, you have full control over the background images by selecting one. You can change their blending mode and
-    opacity so you can see all your background images at once.
+    windows, you have full control over the background images by selecting one. You can change their blending modes and
+    opacities individually.
 
-Specify no background images by setting `#!python background_images=[]`
+Specify no background images by setting `#!python background_images=[]` and `#!python background_image_colours=[]`.
 
 Close the Viewer and all subplots by pressing Ctrl + C in the terminal.
 
@@ -82,9 +82,10 @@ require a selected spot. Select a spot by pressing 3 and clicking on a spot. The
 The "Background Contrast" slider will affect the colour scale of the background image. "Marker Size" will change the
 size of gene spots. "Z Thickness" allows for multiple z planes to be displayed at once. The "Score Thresholds" allows
 the user to change the minimum and maximum spot scores to display. The "Intensity Thresholds" affects the minimum and
-maximum allowed spot intensity to display The "Method" is the chosen method of gene calling. "Probability" is the Von-
-Mises probability method, "Anchor" is the anchor method (see [call spots](overview.md#call-spots)), and "OMP" is the
-Orthogonal Matching Pursuit method (see [OMP](overview.md#orthogonal-matching-pursuit)).
+maximum allowed spot intensity to display. By default, the intensity threshold is set to 0.15. The "Method" is the
+chosen method of gene calling. "Probability" is the Von-Mises probability method and "Anchor" is the anchor method (see
+[call spots](overview.md#call-spots)), and "OMP" is the Orthogonal Matching Pursuit method (see
+[OMP](overview.md#orthogonal-matching-pursuit)).
 
 ??? bug "Max Intensity Projection Toggle"
 
@@ -94,7 +95,6 @@ Orthogonal Matching Pursuit method (see [OMP](overview.md#orthogonal-matching-pu
 
 <figure markdown="span">
   ![Image title](images/Viewer_example.PNG){ width="1100" }
-  <figcaption>The Viewer</figcaption>
 </figure>
 
 ## RegistrationViewer

--- a/docs/export.md
+++ b/docs/export.md
@@ -49,7 +49,7 @@ minimum threshold:
 ```
 
 score_thresh and intensity_thresh must be numbers. Use the [Viewer](diagnostics.md#viewer) to help decide on thresholds.
-intensity_thresh is set to `0.15` in the Viewer by default.
+intensity_thresh is set to `0.15` for OMP in the Viewer by default.
 
 ## Custom Images
 

--- a/docs/omp.md
+++ b/docs/omp.md
@@ -96,7 +96,7 @@ weighted. $\beta$ is given by `beta` (typically 1) and gives every round-channel
 Gene $\tilde{g}$ is successfully assigned to pixel $p$ when all conditions are met:
 
 - $(\text{gene scores})_{p\tilde{g}i}$ is the largest scoring gene.
-- $(\text{gene scores})_{p\tilde{g}i} >$ `dot_product_threshold` (typically 0.5).
+- $(\text{gene scores})_{p\tilde{g}i} >$ `dot_product_threshold` (typically 0.72).
 - $\tilde g$ is not already assigned to the pixel.
 - $\tilde g$ is not a background gene.
 - The residual intensity $\min_r(\max_c(|\hat{R}_{prci}|)) > \text{minimum\_intensity}_t$. See [diagnostic](diagnostics.md#intensity-images).


### PR DESCRIPTION
- **[call spots] intensity threshold on spot selection, closes #337**
- **[viewer] 'prob' gene calling method now shows initial Von-Mises probabilities**
- **[viewer] updated default score/intensity thresholds**
- **[omp] 0.50 -> 0.72 dot_product_threshold default**
- **[register] can now gather spot colours when** $0 \notin \text{use rounds}$

Improvements made based on the dataset BZ004_S24 (Isabelle24).
Changes checked for regressions using the Aang dataset.

### Checklist
- [x] I have created/updated unit tests, if applicable.
- [x] I have updated the `changelog.txt`, if applicable.
- [x] I have bumped the software version in `_version.py`, if applicable.
