### PR TITLE
[omp] crash when trying to overwrite existing tile results fix, closes #435

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 2026/04/21 Version 1.12 Patch (v1.12.1):
  * General: LineStuffUp changed to up-to-date CASTalign.
  * General: Removed runtime estimator.
+ * OMP: Crash when trying to overwrite existing tile results fix.
  * OMP: Slightly faster pixel score computation.
 
 

--- a/coppafisher/pipeline/omp_torch.py
+++ b/coppafisher/pipeline/omp_torch.py
@@ -135,6 +135,9 @@ def run_omp(
     # Every tile's results are appended to a zarr.Group. The zarr group is kept in the output directory until OMP is
     # complete, then it is moved into the 'omp' notebook page.
     results_path = os.path.join(nbp_file.output_dir, "results.zgroup")
+    if not config_unchanged and os.path.isfile(results_path):
+        # Delete the results zgroup because overwriting the data is not possible for a ZipStore.
+        os.remove(results_path)
     results_store = zarr.ZipStore(results_path, mode="a" if os.path.exists(results_path) else "x")
     results = zarr.group(store=results_store, zarr_version=2)
     tile_already_exists = [


### PR DESCRIPTION
### Checklist
- [x] I have created/updated unit tests, if applicable.
- [x] I have updated the `changelog.txt`, if applicable.
- [x] I have bumped the software version in `_version.py`, `pyproject.toml`, and `coppafisher/compatibility/base.py`, if applicable.
